### PR TITLE
弩的充能延迟导致充能失败问题

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemCrossbow.java
+++ b/src/main/java/cn/nukkit/item/ItemCrossbow.java
@@ -175,8 +175,11 @@ public class ItemCrossbow extends ItemTool {
             maxUseDuration -= 5 * quickChargeLevel;
         }
 
-        if ((ticksUsed + 1) < maxUseDuration) {
+        if ((ticksUsed + 1 + 3) < maxUseDuration) {
             return false;
+
+            //考虑玩家延迟3tick，需要增加一个阈值来防止因为延迟导致的充能失败
+            //或者需要在表现动画上加以改进
         }
 
         Item matched;


### PR DESCRIPTION
弩的充能因为玩家延迟不同导致动画与效果过度均不自然，需要增加阈值考虑