### PR TITLE
[codex] Optimize liquid flow scheduling

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -29,6 +29,7 @@ import cn.nukkit.lang.TranslationContainer;
 import cn.nukkit.level.Dimension;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.LevelCreationOptions;
+import cn.nukkit.level.LevelOptimizationSettings;
 import cn.nukkit.level.Position;
 import cn.nukkit.level.biome.Biomes;
 import cn.nukkit.level.format.LevelProvider;
@@ -381,6 +382,7 @@ public class Server {
                 .compressionAlgorithm(Compressor.getAlgorithmByName(getPropertyString("compression-algorithm", "snappy")))
                 .backupPlayerData(getConfig("settings.backup-player-data", true))
                 .backupLevelData(getConfig("level-settings.backup-level-data", true))
+                .defaultLevelOptimizationSettings(readDefaultLevelOptimizationSettings())
                 .build();
 
         this.forceLanguage = this.getConfig("settings.force-language", false);
@@ -2115,6 +2117,20 @@ public class Server {
     public <T> T getConfig(String variable, T defaultValue) {
         Object value = this.config.get(variable);
         return value == null ? defaultValue : (T) value;
+    }
+
+    private LevelOptimizationSettings readDefaultLevelOptimizationSettings() {
+        LevelOptimizationSettings settings = LevelOptimizationSettings.defaults();
+        settings.getLiquidFlow()
+                .setEquivalentOptimizationEnabled(getConfig("optimization.liquid-flow.equivalent-optimization", false))
+                .setVisibilitySchedulingEnabled(getConfig("optimization.liquid-flow.visibility-scheduling", false))
+                .setNormalUpdateDeduplicationEnabled(getConfig("optimization.liquid-flow.normal-update-deduplication", false))
+                .setLiquidUpdateAroundSuppressionEnabled(getConfig("optimization.liquid-flow.liquid-update-around-suppression", false))
+                .setMaxLiquidNormalUpdatesPerTick(getConfig("optimization.liquid-flow.max-liquid-normal-updates-per-tick", -1))
+                .setMaxLiquidScheduledUpdatesPerTick(getConfig("optimization.liquid-flow.max-liquid-scheduled-updates-per-tick", -1))
+                .setVisibilityChunkRadius(getConfig("optimization.liquid-flow.visibility-chunk-radius", 1))
+                .setVisibilitySubChunkRadius(getConfig("optimization.liquid-flow.visibility-sub-chunk-radius", -1));
+        return settings;
     }
 
     public Config getProperties() {

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -17,7 +17,6 @@ import cn.nukkit.network.protocol.LevelSoundEventPacket;
 import cn.nukkit.utils.Hash;
 import it.unimi.dsi.fastutil.longs.Long2ByteMap;
 import it.unimi.dsi.fastutil.longs.Long2ByteOpenHashMap;
-import org.apache.commons.lang3.mutable.MutableInt;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -36,6 +35,10 @@ public abstract class BlockLiquid extends BlockTransparent {
     private static final byte CAN_FLOW_DOWN = 1;
     private static final byte CAN_FLOW = 0;
     private static final byte BLOCKED = -1;
+    private static final int FLOW_WEST = 1;
+    private static final int FLOW_EAST = 1 << 1;
+    private static final int FLOW_NORTH = 1 << 2;
+    private static final int FLOW_SOUTH = 1 << 3;
 
     BlockLiquid() {
     }
@@ -114,6 +117,13 @@ public abstract class BlockLiquid extends BlockTransparent {
         return block.getDamage();
     }
 
+    private int getFlowDecay(int fullId) {
+        if (!isSameLiquidFullId(fullId)) {
+            return -1;
+        }
+        return Block.getDamageFromFullId(fullId);
+    }
+
     protected int getEffectiveFlowDecay(Block block) {
         if (!isSameLiquid(block)) {
             return -1;
@@ -123,6 +133,53 @@ public abstract class BlockLiquid extends BlockTransparent {
             decay = 0;
         }
         return decay;
+    }
+
+    private int getFullBlockFast(int layer, int x, int y, int z) {
+        if (!level.getHeightRange().isValidBlockY(y)) {
+            return Block.getFullId(BlockID.AIR);
+        }
+        return level.getBlockFullIdAt(layer, x, y, z);
+    }
+
+    private boolean isSameLiquidFullId(int fullId) {
+        return isWater() ? isWaterFullId(fullId) : isLavaFullId(fullId);
+    }
+
+    private static boolean isAirFullId(int fullId) {
+        return Block.getIdFromFullId(fullId) == BlockID.AIR;
+    }
+
+    private static boolean isWaterFullId(int fullId) {
+        int id = Block.getIdFromFullId(fullId);
+        return id == BlockID.FLOWING_WATER || id == BlockID.WATER;
+    }
+
+    private static boolean isLavaFullId(int fullId) {
+        int id = Block.getIdFromFullId(fullId);
+        return id == BlockID.FLOWING_LAVA || id == BlockID.LAVA;
+    }
+
+    private static boolean isLiquidFullId(int fullId) {
+        return isWaterFullId(fullId) || isLavaFullId(fullId);
+    }
+
+    private static boolean isWaterSourceFullId(int fullId) {
+        return isWaterFullId(fullId) && Block.getDamageFromFullId(fullId) == 0;
+    }
+
+    private static int getSimpleCanFlowInto(int fullId) {
+        if (isAirFullId(fullId)) {
+            return 1;
+        }
+        if (isLiquidFullId(fullId)) {
+            return Block.getDamageFromFullId(fullId) == 0 ? 0 : 1;
+        }
+        return -1;
+    }
+
+    private static int getSimpleLiquidContainer(int fullId) {
+        return isAirFullId(fullId) || isLiquidFullId(fullId) ? 1 : -1;
     }
 
     public Vector3 getFlowVector() {
@@ -218,24 +275,85 @@ public abstract class BlockLiquid extends BlockTransparent {
             int x = getFloorX();
             int y = getFloorY();
             int z = getFloorZ();
+            boolean equivalentOptimization = this.level.getOptimizationSettings().getLiquidFlow().isEquivalentOptimizationEnabled();
 
             int decay = this.getFlowDecay(this);
             int multiplier = this.getFlowDecayPerBlock();
+            Block cachedBottomBlock = null;
+            Block cachedWestBlock = null;
+            Block cachedEastBlock = null;
+            Block cachedNorthBlock = null;
+            Block cachedSouthBlock = null;
 
             if (decay > 0) {
                 int smallestFlowDecay = -100;
-                MutableInt adjacentSources = new MutableInt();
+                int adjacentSources = 0;
 
-                for (BlockFace side : Plane.HORIZONTAL) {
-                    Block block = getSide(side);
-                    if (!isSameLiquid(block)) {
-                        Block block0 = block;
-                        block = level.getExtraBlock(block);
-                        if (block.isWater() && block0 instanceof BlockStairs stairs && calculateStairsHorizontalOcclusions(stairs).contains(side.getOpposite())) {
-                            continue;
+                if (equivalentOptimization) {
+                    int westFlowDecay = this.getFlowDecay(this.getFullBlockFast(0, x - 1, y, z));
+                    if (westFlowDecay >= 0) {
+                        adjacentSources += this.getAdjacentSourceCount(westFlowDecay);
+                        smallestFlowDecay = this.getSmallestFlowDecay(westFlowDecay, smallestFlowDecay);
+                    } else {
+                        cachedWestBlock = this.level.getBlock(x - 1, y, z);
+                        Block westFlowBlock = this.getHorizontalFlowDecayBlock(cachedWestBlock, BlockFace.WEST);
+                        if (westFlowBlock != null) {
+                            adjacentSources += this.getAdjacentSourceCount(westFlowBlock);
+                            smallestFlowDecay = this.getSmallestFlowDecay(westFlowBlock, smallestFlowDecay);
                         }
                     }
-                    smallestFlowDecay = this.getSmallestFlowDecay(block, smallestFlowDecay, adjacentSources);
+
+                    int eastFlowDecay = this.getFlowDecay(this.getFullBlockFast(0, x + 1, y, z));
+                    if (eastFlowDecay >= 0) {
+                        adjacentSources += this.getAdjacentSourceCount(eastFlowDecay);
+                        smallestFlowDecay = this.getSmallestFlowDecay(eastFlowDecay, smallestFlowDecay);
+                    } else {
+                        cachedEastBlock = this.level.getBlock(x + 1, y, z);
+                        Block eastFlowBlock = this.getHorizontalFlowDecayBlock(cachedEastBlock, BlockFace.EAST);
+                        if (eastFlowBlock != null) {
+                            adjacentSources += this.getAdjacentSourceCount(eastFlowBlock);
+                            smallestFlowDecay = this.getSmallestFlowDecay(eastFlowBlock, smallestFlowDecay);
+                        }
+                    }
+
+                    int northFlowDecay = this.getFlowDecay(this.getFullBlockFast(0, x, y, z - 1));
+                    if (northFlowDecay >= 0) {
+                        adjacentSources += this.getAdjacentSourceCount(northFlowDecay);
+                        smallestFlowDecay = this.getSmallestFlowDecay(northFlowDecay, smallestFlowDecay);
+                    } else {
+                        cachedNorthBlock = this.level.getBlock(x, y, z - 1);
+                        Block northFlowBlock = this.getHorizontalFlowDecayBlock(cachedNorthBlock, BlockFace.NORTH);
+                        if (northFlowBlock != null) {
+                            adjacentSources += this.getAdjacentSourceCount(northFlowBlock);
+                            smallestFlowDecay = this.getSmallestFlowDecay(northFlowBlock, smallestFlowDecay);
+                        }
+                    }
+
+                    int southFlowDecay = this.getFlowDecay(this.getFullBlockFast(0, x, y, z + 1));
+                    if (southFlowDecay >= 0) {
+                        adjacentSources += this.getAdjacentSourceCount(southFlowDecay);
+                        smallestFlowDecay = this.getSmallestFlowDecay(southFlowDecay, smallestFlowDecay);
+                    } else {
+                        cachedSouthBlock = this.level.getBlock(x, y, z + 1);
+                        Block southFlowBlock = this.getHorizontalFlowDecayBlock(cachedSouthBlock, BlockFace.SOUTH);
+                        if (southFlowBlock != null) {
+                            adjacentSources += this.getAdjacentSourceCount(southFlowBlock);
+                            smallestFlowDecay = this.getSmallestFlowDecay(southFlowBlock, smallestFlowDecay);
+                        }
+                    }
+                } else {
+                    for (BlockFace side : Plane.HORIZONTAL) {
+                        Block block = getSide(side);
+                        if (!isSameLiquid(block)) {
+                            Block block0 = block;
+                            block = level.getExtraBlock(block);
+                            if (block.isWater() && block0 instanceof BlockStairs stairs && calculateStairsHorizontalOcclusions(stairs).contains(side.getOpposite())) {
+                                continue;
+                            }
+                        }
+                        adjacentSources += this.getAdjacentSourceCount(block);
+                        smallestFlowDecay = this.getSmallestFlowDecay(block, smallestFlowDecay);
+                    }
                 }
 
                 int newDecay = smallestFlowDecay + multiplier;
@@ -243,25 +361,54 @@ public abstract class BlockLiquid extends BlockTransparent {
                     newDecay = -1;
                 }
 
-                Block above = this.level.getBlock(x, y + 1, z);
-                int topFlowDecay = this.getFlowDecay(above);
-                if (topFlowDecay == -1) {
-                    topFlowDecay = this.getFlowDecay(this.level.getExtraBlock(above));
-                    if (topFlowDecay >= 0 && (above instanceof BlockStairs stairs && !stairs.isUpsideDown() || above instanceof BlockSlab slab && !slab.isTopSlot())) {
-                        // fix https://bugs.mojang.com/browse/MCPE-45071
-                        topFlowDecay = -1;
+                Block above = null;
+                int topFlowDecay;
+                if (equivalentOptimization) {
+                    topFlowDecay = this.getFlowDecay(this.getFullBlockFast(0, x, y + 1, z));
+                    if (topFlowDecay == -1) {
+                        topFlowDecay = this.getFlowDecay(this.getFullBlockFast(1, x, y + 1, z));
+                        if (topFlowDecay >= 0) {
+                            above = this.level.getBlock(x, y + 1, z);
+                            if (above instanceof BlockStairs stairs && !stairs.isUpsideDown() || above instanceof BlockSlab slab && !slab.isTopSlot()) {
+                                // fix https://bugs.mojang.com/browse/MCPE-45071
+                                topFlowDecay = -1;
+                            }
+                        }
+                    }
+                } else {
+                    above = this.level.getBlock(x, y + 1, z);
+                    topFlowDecay = this.getFlowDecay(above);
+                    if (topFlowDecay == -1) {
+                        topFlowDecay = this.getFlowDecay(this.level.getExtraBlock(above));
+                        if (topFlowDecay >= 0 && (above instanceof BlockStairs stairs && !stairs.isUpsideDown() || above instanceof BlockSlab slab && !slab.isTopSlot())) {
+                            // fix https://bugs.mojang.com/browse/MCPE-45071
+                            topFlowDecay = -1;
+                        }
                     }
                 }
                 if (topFlowDecay >= 0) {
                     newDecay = topFlowDecay | DOWNWARD_BIT;
                 }
 
-                if (adjacentSources.intValue() >= 2 && this.isWater()) {
-                    Block bottomBlock = this.level.getBlock(x, y - 1, z);
-                    if (bottomBlock.isSolid()) {
-                        newDecay = 0;
-                    } else if (bottomBlock.isWaterSource() || this.level.getExtraBlock(bottomBlock).isWaterSource()) {
-                        newDecay = 0;
+                if (adjacentSources >= 2 && this.isWater()) {
+                    if (equivalentOptimization) {
+                        int bottomFullId = this.getFullBlockFast(0, x, y - 1, z);
+                        if (isWaterSourceFullId(bottomFullId) || isWaterSourceFullId(this.getFullBlockFast(1, x, y - 1, z))) {
+                            newDecay = 0;
+                        } else if (!isAirFullId(bottomFullId) && !isLiquidFullId(bottomFullId)) {
+                            Block bottomBlock = this.level.getBlock(x, y - 1, z);
+                            cachedBottomBlock = bottomBlock;
+                            if (bottomBlock.isSolid()) {
+                                newDecay = 0;
+                            }
+                        }
+                    } else {
+                        Block bottomBlock = this.level.getBlock(x, y - 1, z);
+                        if (bottomBlock.isSolid()) {
+                            newDecay = 0;
+                        } else if (bottomBlock.isWaterSource() || this.level.getExtraBlock(bottomBlock).isWaterSource()) {
+                            newDecay = 0;
+                        }
                     }
                 }
 
@@ -291,6 +438,11 @@ public abstract class BlockLiquid extends BlockTransparent {
 
                     BlockFromToEvent event = new BlockFromToEvent(this, layer, to);
                     level.getServer().getPluginManager().callEvent(event);
+                    cachedBottomBlock = null;
+                    cachedWestBlock = null;
+                    cachedEastBlock = null;
+                    cachedNorthBlock = null;
+                    cachedSouthBlock = null;
                     if (!event.isCancelled()) {
                         this.level.setBlock(event.getLayer(), this, event.getTo(), true);
 
@@ -305,7 +457,7 @@ public abstract class BlockLiquid extends BlockTransparent {
                 Block container = isWaterSource() ? level.getBlock(this) : null;
                 BlockStairs stairs = container instanceof BlockStairs ? (BlockStairs) container : null;
 
-                Block bottomBlock = this.level.getBlock(x, y - 1, z);
+                Block bottomBlock = cachedBottomBlock != null ? cachedBottomBlock : this.level.getBlock(x, y - 1, z);
                 boolean result = true;
                 if ((stairs == null || stairs.isUpsideDown()) && (!(container instanceof BlockSlab slab) || slab.isTopSlot())) {
                     result = this.flowIntoBlock(bottomBlock, decay | DOWNWARD_BIT);
@@ -321,18 +473,18 @@ public abstract class BlockLiquid extends BlockTransparent {
 
                     if (adjacentDecay < DOWNWARD_BIT) {
                         Set<BlockFace> occlusions = stairs != null ? calculateStairsHorizontalOcclusions(stairs) : Collections.emptySet();
-                        boolean[] flags = this.getOptimalFlowDirections(occlusions);
-                        if (flags[0] && !occlusions.contains(BlockFace.WEST)) {
-                            this.flowIntoBlock(this.level.getBlock(x - 1, y, z), adjacentDecay);
+                        int flowDirectionMask = this.getOptimalFlowDirections(occlusions, equivalentOptimization);
+                        if ((flowDirectionMask & FLOW_WEST) != 0 && !occlusions.contains(BlockFace.WEST)) {
+                            this.flowIntoBlock(cachedWestBlock != null ? cachedWestBlock : this.level.getBlock(x - 1, y, z), adjacentDecay);
                         }
-                        if (flags[1] && !occlusions.contains(BlockFace.EAST)) {
-                            this.flowIntoBlock(this.level.getBlock(x + 1, y, z), adjacentDecay);
+                        if ((flowDirectionMask & FLOW_EAST) != 0 && !occlusions.contains(BlockFace.EAST)) {
+                            this.flowIntoBlock(cachedEastBlock != null ? cachedEastBlock : this.level.getBlock(x + 1, y, z), adjacentDecay);
                         }
-                        if (flags[2] && !occlusions.contains(BlockFace.NORTH)) {
-                            this.flowIntoBlock(this.level.getBlock(x, y, z - 1), adjacentDecay);
+                        if ((flowDirectionMask & FLOW_NORTH) != 0 && !occlusions.contains(BlockFace.NORTH)) {
+                            this.flowIntoBlock(cachedNorthBlock != null ? cachedNorthBlock : this.level.getBlock(x, y, z - 1), adjacentDecay);
                         }
-                        if (flags[3] && !occlusions.contains(BlockFace.SOUTH)) {
-                            this.flowIntoBlock(this.level.getBlock(x, y, z + 1), adjacentDecay);
+                        if ((flowDirectionMask & FLOW_SOUTH) != 0 && !occlusions.contains(BlockFace.SOUTH)) {
+                            this.flowIntoBlock(cachedSouthBlock != null ? cachedSouthBlock : this.level.getBlock(x, y, z + 1), adjacentDecay);
                         }
                     }
                 }
@@ -354,8 +506,17 @@ public abstract class BlockLiquid extends BlockTransparent {
     }
 
     protected boolean flowIntoBlock(Block block, int newFlowDecay) {
+        if (!this.canFlowInto(block) || block.isLiquid()) {
+            return true;
+        }
+
+        if (isEquivalentLiquidOptimizationEnabled()
+                && isLiquidFullId(this.getFullBlockFast(1, block.getFloorX(), block.getFloorY(), block.getFloorZ()))) {
+            return true;
+        }
+
         Block extra = level.getExtraBlock(block);
-        if (this.canFlowInto(block) && !block.isLiquid() && !extra.isLiquid()) {
+        if (!extra.isLiquid()) {
             LiquidFlowEvent event = new LiquidFlowEvent(block, extra, this, newFlowDecay);
             level.getServer().getPluginManager().callEvent(event);
             if (!event.isCancelled()) {
@@ -372,6 +533,10 @@ public abstract class BlockLiquid extends BlockTransparent {
     }
 
     private int calculateFlowCost(int blockX, int blockY, int blockZ, int accumulatedCost, int maxCost, int originOpposite, int lastOpposite, Long2ByteMap flowCostVisited) {
+        return calculateFlowCost(blockX, blockY, blockZ, accumulatedCost, maxCost, originOpposite, lastOpposite, flowCostVisited, false);
+    }
+
+    private int calculateFlowCost(int blockX, int blockY, int blockZ, int accumulatedCost, int maxCost, int originOpposite, int lastOpposite, Long2ByteMap flowCostVisited, boolean equivalentOptimization) {
         int cost = 1000;
         for (int j = 0; j < 4; ++j) {
             if (j == originOpposite || j == lastOpposite) {
@@ -395,17 +560,19 @@ public abstract class BlockLiquid extends BlockTransparent {
             long hash = Hash.hashBlockPos(x, y, z);
             byte status = flowCostVisited.get(hash);
             if (status == Byte.MIN_VALUE) {
-                Block blockSide = this.level.getBlock(x, y, z);
-                if (!this.canFlowInto(blockSide) || this.level.getExtraBlock(x, y, z).isLiquid()) {
-                    status = BLOCKED;
-                    flowCostVisited.put(hash, status);
-                } else if (isLiquidContainer(this.level.getBlock(x, y - 1, z))) {
-                    status = CAN_FLOW_DOWN;
-                    flowCostVisited.put(hash, status);
+                if (equivalentOptimization) {
+                    status = this.getFlowCostStatus(x, y, z);
                 } else {
-                    status = CAN_FLOW;
-                    flowCostVisited.put(hash, status);
+                    Block blockSide = this.level.getBlock(x, y, z);
+                    if (!this.canFlowInto(blockSide) || this.level.getExtraBlock(x, y, z).isLiquid()) {
+                        status = BLOCKED;
+                    } else if (isLiquidContainer(this.level.getBlock(x, y - 1, z))) {
+                        status = CAN_FLOW_DOWN;
+                    } else {
+                        status = CAN_FLOW;
+                    }
                 }
+                flowCostVisited.put(hash, status);
             }
 
             if (status == BLOCKED) {
@@ -418,7 +585,7 @@ public abstract class BlockLiquid extends BlockTransparent {
                 continue;
             }
 
-            int realCost = this.calculateFlowCost(x, y, z, accumulatedCost + 1, maxCost, originOpposite, j ^ 0x01, flowCostVisited);
+            int realCost = this.calculateFlowCost(x, y, z, accumulatedCost + 1, maxCost, originOpposite, j ^ 0x01, flowCostVisited, equivalentOptimization);
             if (realCost < cost) {
                 cost = realCost;
             }
@@ -436,19 +603,18 @@ public abstract class BlockLiquid extends BlockTransparent {
         return 500;
     }
 
-    private boolean[] getOptimalFlowDirections(Set<BlockFace> occlusions) {
-        int[] flowCost = new int[]{
-                1000,
-                1000,
-                1000,
-                1000
-        };
+    private int getOptimalFlowDirections(Set<BlockFace> occlusions, boolean equivalentOptimization) {
+        int westFlowCost = 1000;
+        int eastFlowCost = 1000;
+        int northFlowCost = 1000;
+        int southFlowCost = 1000;
 
         Long2ByteMap flowCostVisited = new Long2ByteOpenHashMap();
         flowCostVisited.defaultReturnValue(Byte.MIN_VALUE);
         int maxCost = 4 / this.getFlowDecayPerBlock();
         for (int j = 0; j < 4; ++j) {
             BlockFace side;
+            int currentFlowCost = 1000;
             int x = (int) this.x;
             int y = (int) this.y;
             int z = (int) this.z;
@@ -466,42 +632,117 @@ public abstract class BlockLiquid extends BlockTransparent {
                 ++z;
             }
 
-            if (occlusions.contains(side) || !this.canFlowInto(this.level.getBlock(x, y, z)) || this.level.getExtraBlock(x, y, z).isLiquid()) {
-                flowCostVisited.put(Hash.hashBlockPos(x, y, z), BLOCKED);
-            } else if (isLiquidContainer(this.level.getBlock(x, y - 1, z))) {
-                flowCostVisited.put(Hash.hashBlockPos(x, y, z), CAN_FLOW_DOWN);
-                flowCost[j] = maxCost = 0;
-            } else if (maxCost > 0) {
-                flowCostVisited.put(Hash.hashBlockPos(x, y, z), CAN_FLOW);
-                flowCost[j] = this.calculateFlowCost(x, y, z, 1, maxCost, j ^ 0x01, j ^ 0x01, flowCostVisited);
-                maxCost = Math.min(maxCost, flowCost[j]);
+            long hash = Hash.hashBlockPos(x, y, z);
+            byte status;
+            if (occlusions.contains(side)) {
+                status = BLOCKED;
+            } else if (equivalentOptimization) {
+                status = this.getFlowCostStatus(x, y, z);
+            } else {
+                Block blockSide = this.level.getBlock(x, y, z);
+                if (!this.canFlowInto(blockSide) || this.level.getExtraBlock(x, y, z).isLiquid()) {
+                    status = BLOCKED;
+                } else if (isLiquidContainer(this.level.getBlock(x, y - 1, z))) {
+                    status = CAN_FLOW_DOWN;
+                } else {
+                    status = CAN_FLOW;
+                }
+            }
+
+            flowCostVisited.put(hash, status);
+            if (status == CAN_FLOW_DOWN) {
+                currentFlowCost = maxCost = 0;
+            } else if (status == CAN_FLOW && maxCost > 0) {
+                currentFlowCost = this.calculateFlowCost(x, y, z, 1, maxCost, j ^ 0x01, j ^ 0x01, flowCostVisited, equivalentOptimization);
+                maxCost = Math.min(maxCost, currentFlowCost);
+            }
+
+            if (j == 0) {
+                westFlowCost = currentFlowCost;
+            } else if (j == 1) {
+                eastFlowCost = currentFlowCost;
+            } else if (j == 2) {
+                northFlowCost = currentFlowCost;
+            } else {
+                southFlowCost = currentFlowCost;
             }
         }
 
-        int minCost = Integer.MAX_VALUE;
-        for (int i = 0; i < 4; i++) {
-            int d = flowCost[i];
-            if (d < minCost) {
-                minCost = d;
-            }
-        }
+        int minCost = Math.min(Math.min(westFlowCost, eastFlowCost), Math.min(northFlowCost, southFlowCost));
 
-        boolean[] isOptimalFlowDirection = new boolean[4];
-        for (int i = 0; i < 4; ++i) {
-            isOptimalFlowDirection[i] = (flowCost[i] == minCost);
+        int optimalFlowDirectionMask = 0;
+        if (westFlowCost == minCost) {
+            optimalFlowDirectionMask |= FLOW_WEST;
         }
-        return isOptimalFlowDirection;
+        if (eastFlowCost == minCost) {
+            optimalFlowDirectionMask |= FLOW_EAST;
+        }
+        if (northFlowCost == minCost) {
+            optimalFlowDirectionMask |= FLOW_NORTH;
+        }
+        if (southFlowCost == minCost) {
+            optimalFlowDirectionMask |= FLOW_SOUTH;
+        }
+        return optimalFlowDirectionMask;
     }
 
-    private int getSmallestFlowDecay(Block block, int decay, MutableInt adjacentSources) {
+    private byte getFlowCostStatus(int x, int y, int z) {
+        int fullId = this.getFullBlockFast(0, x, y, z);
+        int canFlowInto = getSimpleCanFlowInto(fullId);
+        if (canFlowInto == 0) {
+            return BLOCKED;
+        }
+
+        int extraFullId = this.getFullBlockFast(1, x, y, z);
+        if (isLiquidFullId(extraFullId) || !isAirFullId(extraFullId) && this.level.getExtraBlock(x, y, z).isLiquid()) {
+            return BLOCKED;
+        }
+
+        if (canFlowInto < 0 && !this.canFlowInto(this.level.getBlock(x, y, z))) {
+            return BLOCKED;
+        }
+
+        int bottomContainer = getSimpleLiquidContainer(this.getFullBlockFast(0, x, y - 1, z));
+        if (bottomContainer > 0 || bottomContainer < 0 && isLiquidContainer(this.level.getBlock(x, y - 1, z))) {
+            return CAN_FLOW_DOWN;
+        }
+        return CAN_FLOW;
+    }
+
+    private boolean isEquivalentLiquidOptimizationEnabled() {
+        return this.level.getOptimizationSettings().getLiquidFlow().isEquivalentOptimizationEnabled();
+    }
+
+    private Block getHorizontalFlowDecayBlock(Block block, BlockFace side) {
+        if (!isSameLiquid(block)) {
+            Block block0 = block;
+            block = level.getExtraBlock(block);
+            if (block.isWater() && block0 instanceof BlockStairs stairs && calculateStairsHorizontalOcclusions(stairs).contains(side.getOpposite())) {
+                return null;
+            }
+        }
+        return block;
+    }
+
+    private int getAdjacentSourceCount(Block block) {
+        return this.getFlowDecay(block) == 0 ? 1 : 0;
+    }
+
+    private int getAdjacentSourceCount(int blockDecay) {
+        return blockDecay == 0 ? 1 : 0;
+    }
+
+    private int getSmallestFlowDecay(Block block, int decay) {
         int blockDecay = this.getFlowDecay(block);
+        return this.getSmallestFlowDecay(blockDecay, decay);
+    }
+
+    private int getSmallestFlowDecay(int blockDecay, int decay) {
         if (blockDecay < 0) {
             return decay;
         }
 
-        if (blockDecay == 0) {
-            adjacentSources.increment();
-        } else if (blockDecay >= DOWNWARD_BIT) {
+        if (blockDecay >= DOWNWARD_BIT) {
             blockDecay = 0;
         }
         return (decay >= 0 && blockDecay >= decay) ? decay : blockDecay;

--- a/src/main/java/cn/nukkit/block/BlockWater.java
+++ b/src/main/java/cn/nukkit/block/BlockWater.java
@@ -97,8 +97,12 @@ public class BlockWater extends BlockLiquid {
 
     @Override
     protected boolean flowIntoBlock(Block block, int newFlowDecay) {
+        if (!canFlowInto(block) || block.isLiquid()) {
+            return true;
+        }
+
         Block extra = level.getExtraBlock(block);
-        if (!canFlowInto(block) || block.isLiquid() || extra.isLiquid()) {
+        if (extra.isLiquid()) {
             return true;
         }
 

--- a/src/main/java/cn/nukkit/data/ServerConfiguration.java
+++ b/src/main/java/cn/nukkit/data/ServerConfiguration.java
@@ -1,5 +1,6 @@
 package cn.nukkit.data;
 
+import cn.nukkit.level.LevelOptimizationSettings;
 import cn.nukkit.network.CompressionAlgorithm;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -24,6 +25,8 @@ public class ServerConfiguration {
     boolean disableRaknet;
     @Default
     byte compressionAlgorithm = CompressionAlgorithm.SNAPPY;
+    @Default
+    LevelOptimizationSettings defaultLevelOptimizationSettings = LevelOptimizationSettings.defaults();
 
     int chunkSpawnThreshold;
     int chunkSendingPerTick;

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -297,8 +297,11 @@ public class Level implements ChunkManager, Metadatable {
 
     private final BlockUpdateScheduler updateQueue;
     private final BlockUpdateScheduler randomUpdateQueue;
+    private LevelOptimizationSettings optimizationSettings = LevelOptimizationSettings.defaults();
 
     private final Queue<Vector3> normalUpdateQueue = new ConcurrentLinkedDeque<>();
+    private final Queue<Vector3> deferredNormalUpdateQueue = new ArrayDeque<>();
+    private final LongSet normalUpdateQueueIndex = new LongOpenHashSet();
 //    private final TreeSet<BlockUpdateEntry> updateQueue = new TreeSet<>();
 //    private final List<BlockUpdateEntry> nextTickUpdates = Lists.newArrayList();
     //private final Map<BlockVector3, Integer> updateQueueIndex = new HashMap<>();
@@ -393,6 +396,7 @@ public class Level implements ChunkManager, Metadatable {
         this.levelId = levelIdCounter.getAndIncrement();
         this.blockMetadata = new BlockMetadataStore(this);
         this.server = server;
+        this.optimizationSettings = server.getConfiguration().getDefaultLevelOptimizationSettings().copy();
         this.autoSave = server.getAutoSave();
         this.autoCompaction = server.isAutoCompactionEnabled();
         this.folderName = name;
@@ -532,6 +536,7 @@ public class Level implements ChunkManager, Metadatable {
         this.levelId = levelIdCounter.getAndIncrement();
         this.blockMetadata = new BlockMetadataStore(this);
         this.server = parent.server;
+        this.optimizationSettings = parent.getOptimizationSettings().copy();
         this.autoSave = parent.autoSave;
         this.autoCompaction = parent.autoCompaction;
         this.folderName = parent.folderName;
@@ -739,6 +744,17 @@ public class Level implements ChunkManager, Metadatable {
 
     public Server getServer() {
         return server;
+    }
+
+    public LevelOptimizationSettings getOptimizationSettings() {
+        return optimizationSettings;
+    }
+
+    public void setOptimizationSettings(LevelOptimizationSettings optimizationSettings) {
+        this.optimizationSettings = optimizationSettings == null ? LevelOptimizationSettings.defaults() : optimizationSettings.copy();
+        this.updateQueue.refreshOptimizationSettings();
+        this.randomUpdateQueue.refreshOptimizationSettings();
+        this.refreshNormalUpdateQueueIndex();
     }
 
     final public LevelProvider getProvider() {
@@ -1252,6 +1268,29 @@ public class Level implements ChunkManager, Metadatable {
         }
     }
 
+    public boolean hasChunkPlayersNear(int chunkX, int chunkZ, int chunkRadius, int blockY, int subChunkRadius) {
+        int safeChunkRadius = Math.max(0, chunkRadius);
+        int centerSubChunkY = blockY >> 4;
+        for (int x = chunkX - safeChunkRadius; x <= chunkX + safeChunkRadius; x++) {
+            for (int z = chunkZ - safeChunkRadius; z <= chunkZ + safeChunkRadius; z++) {
+                Int2ObjectMap<Player> loaders = this.playerLoaders.get(Level.chunkHash(x, z));
+                if (loaders == null || loaders.isEmpty()) {
+                    continue;
+                }
+                if (subChunkRadius < 0) {
+                    return true;
+                }
+                for (Player player : loaders.values()) {
+                    int playerSubChunkY = player.getFloorY() >> 4;
+                    if (Math.abs(playerSubChunkY - centerSubChunkY) <= subChunkRadius) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     public ChunkLoader[] getChunkLoaders(int chunkX, int chunkZ) {
         long index = Level.chunkHash(chunkX, chunkZ);
         Int2ObjectMap<ChunkLoader> loaders = this.chunkLoaders.get(index);
@@ -1421,26 +1460,46 @@ public class Level implements ChunkManager, Metadatable {
             randomUpdateQueue.tick(getCurrentTick());
         }
 
+        int maxLiquidNormalUpdates = getMaxLiquidNormalUpdatesPerTick();
+        int liquidNormalUpdates = 0;
         Vector3 pos;
         while ((pos = this.normalUpdateQueue.poll()) != null) {
+            removeNormalUpdateQueueIndex(pos);
             Block block = getBlock(pos);
+            if (shouldDeferLiquidNormalUpdate(block, liquidNormalUpdates, maxLiquidNormalUpdates)) {
+                deferNormalUpdate(pos);
+                continue;
+            }
+
             BlockUpdateEvent event = new BlockUpdateEvent(block, 0);
             this.server.getPluginManager().callEvent(event);
 
             if (!event.isCancelled()) {
+                if (block instanceof BlockLiquid) {
+                    liquidNormalUpdates++;
+                }
                 block.onUpdate(BLOCK_UPDATE_NORMAL);
             }
 
             block = getExtraBlock(block);
             if (!block.isAir()) {
+                if (shouldDeferLiquidNormalUpdate(block, liquidNormalUpdates, maxLiquidNormalUpdates)) {
+                    deferNormalUpdate(pos);
+                    continue;
+                }
+
                 event = new BlockUpdateEvent(block, 1);
                 server.getPluginManager().callEvent(event);
 
                 if (!event.isCancelled()) {
+                    if (block instanceof BlockLiquid) {
+                        liquidNormalUpdates++;
+                    }
                     block.onUpdate(BLOCK_UPDATE_NORMAL);
                 }
             }
         }
+        flushDeferredNormalUpdates();
 
         if (!this.updateEntities.isEmpty()) {
             for (long id : new ObjectArrayList<>(this.updateEntities.keySet())) {
@@ -1929,13 +1988,110 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public void updateAround(Vector3 pos) {
-        for (BlockFace face : BlockFace.getValues()) {
-            normalUpdateQueue.add(pos.getSideVec(face));
-        }
+        updateAround(pos.getFloorX(), pos.getFloorY(), pos.getFloorZ());
     }
 
     public void updateAround(int x, int y, int z) {
-        updateAround(new Vector3(x, y, z));
+        enqueueNormalUpdate(x, y - 1, z);
+        enqueueNormalUpdate(x, y + 1, z);
+        enqueueNormalUpdate(x, y, z - 1);
+        enqueueNormalUpdate(x, y, z + 1);
+        enqueueNormalUpdate(x - 1, y, z);
+        enqueueNormalUpdate(x + 1, y, z);
+    }
+
+    private boolean isNormalUpdateDeduplicationEnabled() {
+        return this.optimizationSettings.getLiquidFlow().isNormalUpdateDeduplicationEnabled();
+    }
+
+    private int getMaxLiquidNormalUpdatesPerTick() {
+        return this.optimizationSettings.getLiquidFlow().getMaxLiquidNormalUpdatesPerTick();
+    }
+
+    private boolean shouldDeferLiquidNormalUpdate(Block block, int liquidNormalUpdates, int maxLiquidNormalUpdates) {
+        return maxLiquidNormalUpdates > 0 && liquidNormalUpdates >= maxLiquidNormalUpdates && block instanceof BlockLiquid;
+    }
+
+    private void enqueueNormalUpdate(int x, int y, int z) {
+        if (isNormalUpdateDeduplicationEnabled()) {
+            long hash = Hash.hashBlockPos(x, y, z);
+            synchronized (this.normalUpdateQueueIndex) {
+                if (!this.normalUpdateQueueIndex.add(hash)) {
+                    return;
+                }
+            }
+        }
+        this.normalUpdateQueue.add(new Vector3(x, y, z));
+    }
+
+    private void deferNormalUpdate(Vector3 pos) {
+        if (isNormalUpdateDeduplicationEnabled()) {
+            long hash = Hash.hashBlockPos(pos.getFloorX(), pos.getFloorY(), pos.getFloorZ());
+            synchronized (this.normalUpdateQueueIndex) {
+                if (!this.normalUpdateQueueIndex.add(hash)) {
+                    return;
+                }
+            }
+        }
+        this.deferredNormalUpdateQueue.add(pos);
+    }
+
+    private void flushDeferredNormalUpdates() {
+        Vector3 pos;
+        while ((pos = this.deferredNormalUpdateQueue.poll()) != null) {
+            this.normalUpdateQueue.add(pos);
+        }
+    }
+
+    private void removeNormalUpdateQueueIndex(Vector3 pos) {
+        if (!isNormalUpdateDeduplicationEnabled()) {
+            return;
+        }
+
+        long hash = Hash.hashBlockPos(pos.getFloorX(), pos.getFloorY(), pos.getFloorZ());
+        synchronized (this.normalUpdateQueueIndex) {
+            this.normalUpdateQueueIndex.remove(hash);
+        }
+    }
+
+    private void refreshNormalUpdateQueueIndex() {
+        synchronized (this.normalUpdateQueueIndex) {
+            this.normalUpdateQueueIndex.clear();
+            if (!isNormalUpdateDeduplicationEnabled()) {
+                return;
+            }
+            for (Vector3 pos : this.normalUpdateQueue) {
+                this.normalUpdateQueueIndex.add(Hash.hashBlockPos(pos.getFloorX(), pos.getFloorY(), pos.getFloorZ()));
+            }
+            for (Vector3 pos : this.deferredNormalUpdateQueue) {
+                this.normalUpdateQueueIndex.add(Hash.hashBlockPos(pos.getFloorX(), pos.getFloorY(), pos.getFloorZ()));
+            }
+        }
+    }
+
+    private boolean isLiquidUpdateAroundSuppressed(Block blockPrevious, Block block) {
+        return this.optimizationSettings.getLiquidFlow().isLiquidUpdateAroundSuppressionEnabled()
+                && (blockPrevious instanceof BlockLiquid || block instanceof BlockLiquid);
+    }
+
+    private void updateAroundLiquid(int x, int y, int z) {
+        enqueueNormalUpdateIfLiquid(x, y - 1, z);
+        enqueueNormalUpdateIfLiquid(x, y + 1, z);
+        enqueueNormalUpdateIfLiquid(x, y, z - 1);
+        enqueueNormalUpdateIfLiquid(x, y, z + 1);
+        enqueueNormalUpdateIfLiquid(x - 1, y, z);
+        enqueueNormalUpdateIfLiquid(x + 1, y, z);
+    }
+
+    private void enqueueNormalUpdateIfLiquid(int x, int y, int z) {
+        if (!this.heightRange.isValidBlockY(y)) {
+            return;
+        }
+
+        Block block = getBlock(0, x, y, z);
+        if (block instanceof BlockLiquid || getExtraBlock(block) instanceof BlockLiquid) {
+            enqueueNormalUpdate(x, y, z);
+        }
     }
 
     public void scheduleUpdate(Block pos, int delay) {
@@ -2851,6 +3007,7 @@ public class Level implements ChunkManager, Metadatable {
                 addLightUpdate(x, y, z);
             }
 
+            boolean suppressLiquidUpdateAround = isLiquidUpdateAroundSuppressed(blockPrevious, block);
             BlockUpdateEvent ev = new BlockUpdateEvent(block, layer);
             this.server.getPluginManager().callEvent(ev);
             if (!ev.isCancelled()) {
@@ -2870,7 +3027,11 @@ public class Level implements ChunkManager, Metadatable {
                     anotherBlock.onUpdate(BLOCK_UPDATE_NORMAL);
                 }
 
-                this.updateAround(x, y, z);
+                if (!suppressLiquidUpdateAround) {
+                    this.updateAround(x, y, z);
+                } else {
+                    this.updateAroundLiquid(x, y, z);
+                }
 
                 if (block.hasComparatorInputOverride()) {
                     this.updateComparatorOutputLevel(block);

--- a/src/main/java/cn/nukkit/level/LevelOptimizationSettings.java
+++ b/src/main/java/cn/nukkit/level/LevelOptimizationSettings.java
@@ -1,0 +1,119 @@
+package cn.nukkit.level;
+
+/**
+ * Level 级优化配置，默认关闭所有可能影响行为的优化。
+ */
+public class LevelOptimizationSettings {
+
+    private final LiquidFlowSettings liquidFlow = new LiquidFlowSettings();
+
+    public LiquidFlowSettings getLiquidFlow() {
+        return liquidFlow;
+    }
+
+    public static LevelOptimizationSettings defaults() {
+        return new LevelOptimizationSettings();
+    }
+
+    public LevelOptimizationSettings copy() {
+        LevelOptimizationSettings settings = new LevelOptimizationSettings();
+        settings.getLiquidFlow().copyFrom(this.liquidFlow);
+        return settings;
+    }
+
+    public static class LiquidFlowSettings {
+
+        private boolean equivalentOptimizationEnabled;
+        private boolean visibilitySchedulingEnabled;
+        private boolean normalUpdateDeduplicationEnabled;
+        private boolean liquidUpdateAroundSuppressionEnabled;
+        private int maxLiquidNormalUpdatesPerTick = -1;
+        private int maxLiquidScheduledUpdatesPerTick = -1;
+        private int visibilityChunkRadius = 1;
+        private int visibilitySubChunkRadius = -1;
+
+        public boolean isEquivalentOptimizationEnabled() {
+            return equivalentOptimizationEnabled;
+        }
+
+        public LiquidFlowSettings setEquivalentOptimizationEnabled(boolean equivalentOptimizationEnabled) {
+            this.equivalentOptimizationEnabled = equivalentOptimizationEnabled;
+            return this;
+        }
+
+        public boolean isVisibilitySchedulingEnabled() {
+            return visibilitySchedulingEnabled;
+        }
+
+        public LiquidFlowSettings setVisibilitySchedulingEnabled(boolean visibilitySchedulingEnabled) {
+            this.visibilitySchedulingEnabled = visibilitySchedulingEnabled;
+            return this;
+        }
+
+        public boolean isNormalUpdateDeduplicationEnabled() {
+            return normalUpdateDeduplicationEnabled;
+        }
+
+        public LiquidFlowSettings setNormalUpdateDeduplicationEnabled(boolean normalUpdateDeduplicationEnabled) {
+            this.normalUpdateDeduplicationEnabled = normalUpdateDeduplicationEnabled;
+            return this;
+        }
+
+        public boolean isLiquidUpdateAroundSuppressionEnabled() {
+            return liquidUpdateAroundSuppressionEnabled;
+        }
+
+        public LiquidFlowSettings setLiquidUpdateAroundSuppressionEnabled(boolean liquidUpdateAroundSuppressionEnabled) {
+            this.liquidUpdateAroundSuppressionEnabled = liquidUpdateAroundSuppressionEnabled;
+            return this;
+        }
+
+        public int getMaxLiquidNormalUpdatesPerTick() {
+            return maxLiquidNormalUpdatesPerTick;
+        }
+
+        public LiquidFlowSettings setMaxLiquidNormalUpdatesPerTick(int maxLiquidNormalUpdatesPerTick) {
+            this.maxLiquidNormalUpdatesPerTick = maxLiquidNormalUpdatesPerTick;
+            return this;
+        }
+
+        public int getMaxLiquidScheduledUpdatesPerTick() {
+            return maxLiquidScheduledUpdatesPerTick;
+        }
+
+        public LiquidFlowSettings setMaxLiquidScheduledUpdatesPerTick(int maxLiquidScheduledUpdatesPerTick) {
+            this.maxLiquidScheduledUpdatesPerTick = maxLiquidScheduledUpdatesPerTick;
+            return this;
+        }
+
+        public int getVisibilityChunkRadius() {
+            return visibilityChunkRadius;
+        }
+
+        public LiquidFlowSettings setVisibilityChunkRadius(int visibilityChunkRadius) {
+            this.visibilityChunkRadius = Math.max(0, visibilityChunkRadius);
+            return this;
+        }
+
+        public int getVisibilitySubChunkRadius() {
+            return visibilitySubChunkRadius;
+        }
+
+        public LiquidFlowSettings setVisibilitySubChunkRadius(int visibilitySubChunkRadius) {
+            this.visibilitySubChunkRadius = visibilitySubChunkRadius;
+            return this;
+        }
+
+        public LiquidFlowSettings copyFrom(LiquidFlowSettings settings) {
+            this.equivalentOptimizationEnabled = settings.equivalentOptimizationEnabled;
+            this.visibilitySchedulingEnabled = settings.visibilitySchedulingEnabled;
+            this.normalUpdateDeduplicationEnabled = settings.normalUpdateDeduplicationEnabled;
+            this.liquidUpdateAroundSuppressionEnabled = settings.liquidUpdateAroundSuppressionEnabled;
+            this.maxLiquidNormalUpdatesPerTick = settings.maxLiquidNormalUpdatesPerTick;
+            this.maxLiquidScheduledUpdatesPerTick = settings.maxLiquidScheduledUpdatesPerTick;
+            this.visibilityChunkRadius = settings.visibilityChunkRadius;
+            this.visibilitySubChunkRadius = settings.visibilitySubChunkRadius;
+            return this;
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/scheduler/BlockUpdateScheduler.java
+++ b/src/main/java/cn/nukkit/scheduler/BlockUpdateScheduler.java
@@ -1,11 +1,15 @@
 package cn.nukkit.scheduler;
 
 import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockLiquid;
 import cn.nukkit.level.Level;
+import cn.nukkit.level.LevelOptimizationSettings;
 import cn.nukkit.math.AxisAlignedBB;
-import cn.nukkit.math.Mth;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.utils.BlockUpdateEntry;
+import cn.nukkit.utils.Hash;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
@@ -16,11 +20,17 @@ import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockUpdateScheduler {
+    private static final int QUEUED_UPDATE_INDEX_EMPTY_KEY_REBUILD_THRESHOLD = 4096;
+
     private final Level level;
     private long lastTick;
     private final Long2ObjectMap<Set<BlockUpdateEntry>> queuedUpdates;
+    private Long2ObjectMap<IntSet> queuedUpdateIndex;
+    private boolean queuedUpdateIndexEnabled;
+    private int queuedUpdateIndexEmptyKeys;
 
     private Set<BlockUpdateEntry> pendingUpdates;
 
@@ -55,24 +65,45 @@ public class BlockUpdateScheduler {
     private void perform(long tick) {
         try {
             lastTick = tick;
+            boolean useQueuedUpdateIndex = syncQueuedUpdateIndex();
             Set<BlockUpdateEntry> updates = pendingUpdates = queuedUpdates.remove(tick);
             if (updates != null) {
+                int maxLiquidScheduledUpdates = getMaxLiquidScheduledUpdatesPerTick();
+                int remainingLiquidScheduledUpdates = countLiquidScheduledUpdates(updates, maxLiquidScheduledUpdates);
+                int remainingLiquidScheduledSelections = Math.min(maxLiquidScheduledUpdates, remainingLiquidScheduledUpdates);
                 Iterator<BlockUpdateEntry> updateIterator = updates.iterator();
 
                 while (updateIterator.hasNext()) {
                     BlockUpdateEntry entry = updateIterator.next();
+                    if (useQueuedUpdateIndex) {
+                        removeFromQueuedUpdateIndex(entry);
+                    }
+
+                    if (shouldDeferLiquidScheduledEntry(entry, maxLiquidScheduledUpdates, remainingLiquidScheduledUpdates, remainingLiquidScheduledSelections)) {
+                        remainingLiquidScheduledUpdates--;
+                        updateIterator.remove();
+                        rescheduleNextTick(entry, tick);
+                        continue;
+                    }
+                    if (isLiquidScheduledEntry(entry) && maxLiquidScheduledUpdates > 0 && remainingLiquidScheduledUpdates > 0) {
+                        remainingLiquidScheduledUpdates--;
+                        remainingLiquidScheduledSelections--;
+                    }
 
                     Vector3 pos = entry.pos;
-                    if (level.isChunkLoaded(Mth.floor(pos.x) >> 4, Mth.floor(pos.z) >> 4)) {
-                        Block block = level.getBlock(entry.pos);
+                    int x = pos.getFloorX();
+                    int y = pos.getFloorY();
+                    int z = pos.getFloorZ();
+                    if (level.isChunkLoaded(x >> 4, z >> 4)) {
+                        Block block = level.getBlock(x, y, z);
 
                         updateIterator.remove();
                         if (Block.equals(block, entry.block, false)) {
-                            block.onUpdate(Level.BLOCK_UPDATE_SCHEDULED);
+                            processScheduledUpdate(block);
                         } else {
-                            block = level.getExtraBlock(entry.pos);
+                            block = level.getExtraBlock(x, y, z);
                             if (Block.equals(block, entry.block, false)) {
-                                block.onUpdate(Level.BLOCK_UPDATE_SCHEDULED);
+                                processScheduledUpdate(block);
                             }
                         }
                     } else {
@@ -80,9 +111,83 @@ public class BlockUpdateScheduler {
                     }
                 }
             }
+            if (useQueuedUpdateIndex) {
+                compactQueuedUpdateIndex();
+            }
         } finally {
             pendingUpdates = null;
         }
+    }
+
+    private int getMaxLiquidScheduledUpdatesPerTick() {
+        return level.getOptimizationSettings().getLiquidFlow().getMaxLiquidScheduledUpdatesPerTick();
+    }
+
+    private int countLiquidScheduledUpdates(Set<BlockUpdateEntry> updates, int maxLiquidScheduledUpdates) {
+        if (maxLiquidScheduledUpdates <= 0) {
+            return 0;
+        }
+
+        int liquidUpdates = 0;
+        for (BlockUpdateEntry entry : updates) {
+            if (isLiquidScheduledEntry(entry)) {
+                liquidUpdates++;
+            }
+        }
+        return liquidUpdates;
+    }
+
+    private boolean shouldDeferLiquidScheduledEntry(BlockUpdateEntry entry, int maxLiquidScheduledUpdates,
+                                                   int remainingLiquidScheduledUpdates, int remainingLiquidScheduledSelections) {
+        if (maxLiquidScheduledUpdates <= 0 || !isLiquidScheduledEntry(entry)) {
+            return false;
+        }
+        if (remainingLiquidScheduledUpdates <= remainingLiquidScheduledSelections) {
+            return false;
+        }
+        if (remainingLiquidScheduledSelections <= 0) {
+            return true;
+        }
+
+        // 对同 tick 到期的液体更新做等概率抽样，避免固定坐标先执行导致半边水流停滞。
+        return ThreadLocalRandom.current().nextInt(remainingLiquidScheduledUpdates) >= remainingLiquidScheduledSelections;
+    }
+
+    private boolean isLiquidScheduledEntry(BlockUpdateEntry entry) {
+        return entry.block instanceof BlockLiquid;
+    }
+
+    private void processScheduledUpdate(Block block) {
+        if (shouldDeferLiquidUpdate(block)) {
+            level.scheduleUpdate(block, block, block.tickRate());
+            return;
+        }
+
+        block.onUpdate(Level.BLOCK_UPDATE_SCHEDULED);
+    }
+
+    private void rescheduleNextTick(BlockUpdateEntry entry, long tick) {
+        long nextTick = Math.max(tick + 1, level.getCurrentTick() + 1);
+        add(new BlockUpdateEntry(entry.pos, entry.block, nextTick, entry.priority));
+    }
+
+    private boolean shouldDeferLiquidUpdate(Block block) {
+        if (!(block instanceof BlockLiquid)) {
+            return false;
+        }
+
+        LevelOptimizationSettings.LiquidFlowSettings settings = level.getOptimizationSettings().getLiquidFlow();
+        if (!settings.isVisibilitySchedulingEnabled()) {
+            return false;
+        }
+
+        return !level.hasChunkPlayersNear(
+                block.getChunkX(),
+                block.getChunkZ(),
+                settings.getVisibilityChunkRadius(),
+                block.getFloorY(),
+                settings.getVisibilitySubChunkRadius()
+        );
     }
 
     public Set<BlockUpdateEntry> getPendingBlockUpdates(AxisAlignedBB boundingBox) {
@@ -117,16 +222,23 @@ public class BlockUpdateScheduler {
     }
 
     public void add(BlockUpdateEntry entry) {
+        boolean useQueuedUpdateIndex = syncQueuedUpdateIndex();
         long time = getMinTime(entry);
         Set<BlockUpdateEntry> updateSet = queuedUpdates.get(time);
         if (updateSet == null) {
             updateSet = new ObjectLinkedOpenHashSet<>();
             queuedUpdates.put(time, updateSet);
         }
-        updateSet.add(entry);
+        if (updateSet.add(entry) && useQueuedUpdateIndex) {
+            addToQueuedUpdateIndex(entry);
+        }
     }
 
     public boolean contains(BlockUpdateEntry entry) {
+        if (syncQueuedUpdateIndex()) {
+            return containsQueuedUpdateIndex(entry);
+        }
+
         for (Long2ObjectMap.Entry<Set<BlockUpdateEntry>> tickUpdateSet : queuedUpdates.long2ObjectEntrySet()) {
             if (tickUpdateSet.getValue().contains(entry)) {
                 return true;
@@ -136,8 +248,12 @@ public class BlockUpdateScheduler {
     }
 
     public boolean remove(BlockUpdateEntry entry) {
+        boolean useQueuedUpdateIndex = syncQueuedUpdateIndex();
         for (Long2ObjectMap.Entry<Set<BlockUpdateEntry>> tickUpdateSet : queuedUpdates.long2ObjectEntrySet()) {
             if (tickUpdateSet.getValue().remove(entry)) {
+                if (useQueuedUpdateIndex) {
+                    removeFromQueuedUpdateIndex(entry);
+                }
                 return true;
             }
         }
@@ -145,12 +261,113 @@ public class BlockUpdateScheduler {
     }
 
     public boolean remove(Vector3 pos) {
+        boolean useQueuedUpdateIndex = syncQueuedUpdateIndex();
         for (Long2ObjectMap.Entry<Set<BlockUpdateEntry>> tickUpdateSet : queuedUpdates.long2ObjectEntrySet()) {
-            if (tickUpdateSet.getValue().remove(pos)) {
-                return true;
+            Iterator<BlockUpdateEntry> updateIterator = tickUpdateSet.getValue().iterator();
+            while (updateIterator.hasNext()) {
+                BlockUpdateEntry update = updateIterator.next();
+                if (update.pos.equals(pos)) {
+                    updateIterator.remove();
+                    if (useQueuedUpdateIndex) {
+                        removeFromQueuedUpdateIndex(update);
+                    }
+                    return true;
+                }
             }
         }
         return false;
+    }
+
+    private boolean syncQueuedUpdateIndex() {
+        boolean enabled = level.getOptimizationSettings().getLiquidFlow().isEquivalentOptimizationEnabled();
+        if (enabled == queuedUpdateIndexEnabled) {
+            return enabled;
+        }
+
+        queuedUpdateIndexEnabled = enabled;
+        if (!enabled) {
+            if (queuedUpdateIndex != null) {
+                queuedUpdateIndex.clear();
+            }
+            queuedUpdateIndexEmptyKeys = 0;
+            return false;
+        }
+
+        if (queuedUpdateIndex == null) {
+            queuedUpdateIndex = new Long2ObjectOpenHashMap<>();
+        } else {
+            queuedUpdateIndex.clear();
+        }
+        queuedUpdateIndexEmptyKeys = 0;
+
+        for (Set<BlockUpdateEntry> tickUpdateSet : queuedUpdates.values()) {
+            for (BlockUpdateEntry entry : tickUpdateSet) {
+                addToQueuedUpdateIndex(entry);
+            }
+        }
+        return true;
+    }
+
+    private void addToQueuedUpdateIndex(BlockUpdateEntry entry) {
+        long key = getQueuedUpdateIndexKey(entry);
+        IntSet blockIds = queuedUpdateIndex.get(key);
+        if (blockIds == null) {
+            blockIds = new IntOpenHashSet(1);
+            queuedUpdateIndex.put(key, blockIds);
+        } else if (blockIds.isEmpty()) {
+            queuedUpdateIndexEmptyKeys--;
+        }
+        blockIds.add(entry.block.getId());
+    }
+
+    private boolean containsQueuedUpdateIndex(BlockUpdateEntry entry) {
+        IntSet blockIds = queuedUpdateIndex.get(getQueuedUpdateIndexKey(entry));
+        return blockIds != null && blockIds.contains(entry.block.getId());
+    }
+
+    private void removeFromQueuedUpdateIndex(BlockUpdateEntry entry) {
+        long key = getQueuedUpdateIndexKey(entry);
+        IntSet blockIds = queuedUpdateIndex.get(key);
+        if (blockIds == null) {
+            return;
+        }
+
+        if (blockIds.remove(entry.block.getId()) && blockIds.isEmpty()) {
+            queuedUpdateIndexEmptyKeys++;
+        }
+    }
+
+    private void compactQueuedUpdateIndex() {
+        if (queuedUpdateIndex == null || queuedUpdateIndex.isEmpty()) {
+            queuedUpdateIndexEmptyKeys = 0;
+            return;
+        }
+
+        if (queuedUpdates.isEmpty()) {
+            queuedUpdateIndex.clear();
+            queuedUpdateIndexEmptyKeys = 0;
+            return;
+        }
+
+        if (queuedUpdateIndexEmptyKeys >= QUEUED_UPDATE_INDEX_EMPTY_KEY_REBUILD_THRESHOLD
+                && queuedUpdateIndexEmptyKeys * 2 >= queuedUpdateIndex.size()) {
+            queuedUpdateIndex.clear();
+            queuedUpdateIndexEmptyKeys = 0;
+            for (Set<BlockUpdateEntry> tickUpdateSet : queuedUpdates.values()) {
+                for (BlockUpdateEntry entry : tickUpdateSet) {
+                    addToQueuedUpdateIndex(entry);
+                }
+            }
+        }
+    }
+
+    private long getQueuedUpdateIndexKey(BlockUpdateEntry entry) {
+        Vector3 pos = entry.pos;
+        return Hash.hashBlockPos(pos.getFloorX(), pos.getFloorY(), pos.getFloorZ());
+    }
+
+    public void refreshOptimizationSettings() {
+        syncQueuedUpdateIndex();
     }
 
     /**


### PR DESCRIPTION
## 背景

本轮优化来自高空并排水源/收起水源后的压测与多份 JFR 对比。测试中发现：当大量流动水在同一平面高度同步消退时，TPS 会突然下降；早期热点集中在液体 `setBlock -> updateAround -> normalUpdate -> scheduleUpdate` 的普通更新放大，后续削减后，热点进一步转移到同一 tick 内大量 scheduled liquid update 集中执行，以及每个液体更新带来的 `Block` clone、事件、发包和调度器维护成本。

这个 PR 把相关优化全部做成 Level/global 级可控实验特性，默认关闭，避免影响普通生产世界；小游戏（例如 BedWars）可以按 Level 灰度启用并随时回撤。

## 主要改动

- 新增 `LevelOptimizationSettings`，作为 Level 级优化配置入口，避免在 `Level` 上散落多个 bool。
- 从 `nukkit.yml` 读取全局默认液体优化配置，新 Level 初始化时复制一份配置，插件仍可按 Level 覆盖。
- `BlockUpdateScheduler` 等价优化索引：
  - 在 `equivalentOptimizationEnabled=true` 时启用位置 + block id 的 primitive 去重索引；
  - 降低 `contains()` 扫描所有 tick bucket 的成本；
  - 支持运行中开关切换、索引重建/清空；
  - 避免在热路径上对大索引做整批 `removeAll`。
- `BlockLiquid` 等价降分配：
  - 在安全位置复用 existing full-id API，降低重复 `Block` clone；
  - 将局部方向结果改成 bit mask；
  - 缓存单次更新内的相邻方块读取；
  - 保持 `tickRate()`、decay、事件和 `setBlock(update=true)` 语义。
- 新增非等价实验开关用于削峰：
  - `normalUpdateDeduplicationEnabled`：同 tick 内 normal update 按坐标去重；
  - `liquidUpdateAroundSuppressionEnabled`：液体变化时抑制完整 6 邻域普通更新，但仍唤醒相邻液体，避免收水后水完全不更新；
  - `maxLiquidNormalUpdatesPerTick`：限制每 tick 液体 normal update；
  - `maxLiquidScheduledUpdatesPerTick`：限制每 tick scheduled liquid update。
- `maxLiquidScheduledUpdatesPerTick` 使用随机抽样，而不是固定执行队列前 N 个，避免同一平面水流出现固定一侧先动、另一侧长期停滞。

## 行为与风险

- 默认配置全部关闭，未配置服务器行为不变。
- `equivalentOptimizationEnabled` 仍用于严格等价优化，不承载跳过事件/跳过更新之类非等价行为。
- `normalUpdateDeduplicationEnabled`、`liquidUpdateAroundSuppressionEnabled`、`maxLiquidNormalUpdatesPerTick`、`maxLiquidScheduledUpdatesPerTick` 都属于实验特性，可能改变极端水流场景的演化节奏。
- scheduled liquid 限额不做追赶补算，目的是削掉同平面瞬时尖峰；代价是大规模水流消退可能更慢。
- 语言模板更新已通过 fork 提交到 Nukkit/Languages PR: https://github.com/Nukkit/Languages/pull/77。由于当前账号没有 Nukkit/Languages 上游直接推送权限，本 PR 没有携带 Languages 子模块指针变更；代码读取缺失配置时会使用默认关闭值。

## 验证

- `./gradlew :Nukkit:compileJava :ECBedWars:compileJava`
- `git -C /Users/fangyizhou/Documents/coding/CodeFunCore/Nukkit diff --check`
- `git -C /Users/fangyizhou/Documents/coding/CodeFunCore/Nukkit/src/main/resources/lang diff --check`
- `git -C /Users/fangyizhou/Documents/coding/CodeFunCore diff --check -- ECBedWars/src/main/java/net/easecation/ecbedwars/stage/BedWarsStage.java`
- `./gradlew :Nukkit:shadowJar`
- `_simple/nukkit.jar` SHA256: `65404666c94923541082e20cd1fba20b56a1bf33cc417c4a77d3cfc921509006`
