### PR TITLE
Add opt-in damage cooldown and projectile preparation hooks

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityDamageEventPreprocessor.java
+++ b/src/main/java/cn/nukkit/entity/EntityDamageEventPreprocessor.java
@@ -1,0 +1,12 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.event.entity.EntityDamageEvent;
+
+/**
+ * 允许伤害来源在目标进入连续攻击冷却门控前补充事件属性。
+ */
+@FunctionalInterface
+public interface EntityDamageEventPreprocessor {
+
+    void prepareDamageEvent(EntityDamageEvent event);
+}

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -189,8 +189,15 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
         long time = 0;
         if (notSuicide) {
             time = System.currentTimeMillis();
-            // 冷却中
-            if (time < this.nextAllowAttack) {
+            if (source.isBypassAttackCooldown()) {
+                // 独立追加伤害不读取或改写普通攻击的差额伤害状态。
+                if (!damageEntity0(source)) {
+                    return false;
+                }
+                knockback = true;
+                hurtAnimationSelf = true;
+            } else if (time < this.nextAllowAttack) {
+                // 冷却中
                 if (damage > 0) {
                     if (damage <= this.lastHurt) {
                         return false;

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -171,6 +171,10 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
                 return false;
             }
         }
+        if (source instanceof EntityDamageByEntityEvent damageByEntityEvent
+                && damageByEntityEvent.getDamager() instanceof EntityDamageEventPreprocessor preprocessor) {
+            preprocessor.prepareDamageEvent(source);
+        }
 
         boolean notSuicide = source.getCause() != DamageCause.SUICIDE;
         if (notSuicide) {

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -122,6 +122,7 @@ public abstract class EntityProjectile extends Entity {
             if (this.knockbackEnchantLevel > 0) {
                 ((EntityDamageByEntityEvent) ev).getKnockbackProfile().setEnchantLevel(this.knockbackEnchantLevel);
             }
+            this.prepareDamageEvent(ev);
             dealDamage = entity.attack(ev);
         } else {
             dealDamage = false;
@@ -160,6 +161,12 @@ public abstract class EntityProjectile extends Entity {
     }
 
     protected void postHurt(Entity entity) {
+    }
+
+    /**
+     * 允许专用投射物在伤害提交前补充事件语义；默认不改变原版投射物行为。
+     */
+    protected void prepareDamageEvent(EntityDamageEvent event) {
     }
 
     protected void onHitBlock(MovingObjectPosition blockHitResult) {

--- a/src/main/java/cn/nukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityDamageEvent.java
@@ -22,6 +22,7 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
     }
 
     private int attackCooldown = 10;
+    private boolean bypassAttackCooldown;
     private final DamageCause cause;
 
     private final Map<DamageModifier, Float> modifiers;
@@ -114,6 +115,19 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
 
     public void setAttackCooldown(int attackCooldown) {
         this.attackCooldown = attackCooldown;
+    }
+
+    /**
+     * 是否让本次独立伤害不参与连续攻击的 lastHurt/nextAllowAttack 门控。
+     * 默认关闭；开启后仍会经过事件、无敌帧、护甲和正常受伤回调。
+     * 必须在调用实体的 attack 方法前设置，事件监听器内再修改无法绕过已经执行的门控。
+     */
+    public boolean isBypassAttackCooldown() {
+        return bypassAttackCooldown;
+    }
+
+    public void setBypassAttackCooldown(boolean bypassAttackCooldown) {
+        this.bypassAttackCooldown = bypassAttackCooldown;
     }
 
     public boolean canBeReducedByArmor() {

--- a/src/main/java/cn/nukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityDamageEvent.java
@@ -120,7 +120,7 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
     /**
      * 是否让本次独立伤害不参与连续攻击的 lastHurt/nextAllowAttack 门控。
      * 默认关闭；开启后仍会经过事件、无敌帧、护甲和正常受伤回调。
-     * 必须在调用实体的 attack 方法前设置，事件监听器内再修改无法绕过已经执行的门控。
+     * 必须在 lastHurt/nextAllowAttack 门控前设置，普通伤害事件监听器内再修改已经太晚。
      */
     public boolean isBypassAttackCooldown() {
         return bypassAttackCooldown;


### PR DESCRIPTION
## 变更

- 为 `EntityDamageEvent` 增加默认关闭的 `bypassAttackCooldown` 标记，使独立追加伤害可以跳过 `lastHurt / nextAllowAttack` 门控。
- 为 `EntityProjectile` 增加默认空实现的伤害事件预处理 hook，供专用投射物在提交伤害前补充事件语义。
- 增加 `EntityDamageEventPreprocessor`，在连续普通攻击冷却判断前让攻击者有一次默认无行为的事件预处理机会。
- 未显式启用或实现时，保留现有实体、投射物和所有游戏模式的原有行为。

## 安全边界

- 预处理只位于 `EntityLiving.damageEntity0` 的普通冷却门控前；事件已经取消时不会进入该路径。
- 接口默认实现不修改事件；CodeFunCore 的 `Stage.preparePlayerAttackDamage` 也默认为空，仅 Rift Stage 显式处理猎矛门控。
- `bypassAttackCooldown` 只跳过 `lastHurt / nextAllowAttack` 的比较和更新，仍保留事件取消、`noDamageTicks`、复活保护、护甲、附魔保护、吸收、图腾和正常受伤回调。
- Rift 猎矛按攻击者共享 10 tick 服务端门控，换目标或在玩家/怪物之间切换都不能绕过；普通剑与其他模式不进入该门控。

## 验证

- Nukkit 提交：`bcd7d481cd3df441262041886c7410ad85a75dd3`
- Nukkit PR 的 Java 25 与 Publish 检查均通过。
- `./gradlew :ECBedWars:compileJava --rerun-tasks :ECBedWars:copyShadowJar :nukkit:copyShadowJar`
- Nukkit 与主仓 `git diff --check`
- 基于最终复制产物冷启动在 25.56 秒到达 `Done`，Mobrain、ECBedWars 与 Rift 11 图/RMI Stage 均正常注册，随后 `stop` 以 0 退出。
- 多代理静态隔离复核未发现普通 BedWars、Crazy 或既有 Crystal 的 P0/P1/P2 行为回归。

## 合并顺序

CodeFunCore#446 的主仓 gitlink 指向本 PR 头提交。请先将本 PR 合入 Nukkit `master`；若最终 merge SHA 与 `bcd7d481c` 不同，再更新 CodeFunCore gitlink，避免主仓长期引用仅由功能分支保活的子模块对象。
